### PR TITLE
Pass additional arguments passed to ssm-session through to CLI.

### DIFF
--- a/ssm-session
+++ b/ssm-session
@@ -65,22 +65,25 @@ Author: Michael Ludvig
 '''
 
     # Parse supplied arguments
-    args = parser.parse_args(argv)
-
-    return args
+    return parser.parse_known_args(argv)
 
 def update_env(env, var_names, var_value):
     if var_names and var_value:
         for var_name in var_names.split(','):
             env[var_name] = var_value
 
-def start_session(instance_id, profile=None, region=None):
+def start_session(instance_id, extras, profile=None, region=None):
     extra_args = ""
     if profile:
         extra_args += f"--profile {profile} "
     if region:
         extra_args += f"--region {region} "
-    command = f'aws {extra_args} ssm start-session --target {instance_id}'
+        
+    parameters = ""
+    for extra in extras:
+      parameters += f" {extra}"
+
+    command = f'aws {extra_args} ssm start-session --target {instance_id}{parameters}'
     logger.info("Running: %s", command)
     os.system(command)
 
@@ -199,7 +202,7 @@ class InstanceResolver():
 
 if __name__ == "__main__":
     ## Split command line to main args and optional command to run
-    args = parse_args(sys.argv[1:])
+    args, extras = parse_args(sys.argv[1:])
 
     logger = configure_logging(args.log_level)
 
@@ -216,7 +219,7 @@ if __name__ == "__main__":
             logger.warning("Perhaps the '%s' is not registered in SSM?", args.INSTANCE)
             quit(1)
 
-        start_session(instance, profile=args.profile, region=args.region)
+        start_session(instance, extras, profile=args.profile, region=args.region)
 
     except (botocore.exceptions.BotoCoreError,
             botocore.exceptions.ClientError) as e:


### PR DESCRIPTION
In particular, this allows ssm-session to be used with https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html