### PR TITLE
Convert to python2

### DIFF
--- a/ssm-session
+++ b/ssm-session
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Convenience wrapper around 'aws ssm start-session'
 # can resolve instance id from Name tag, hostname, IP address, etc.
@@ -54,10 +54,10 @@ def parse_args(argv):
     group_instance.add_argument('--list', '-l', dest='list', action="store_true", help='List instances available for SSM Session')
 
     parser.description = 'Start SSM Shell Session to a given instance'
-    parser.epilog = f'''
+    parser.epilog = '''
 IMPORTANT: instances must be registered in AWS Systems Manager (SSM)
 before you can start a shell session! Instances not registered in SSM
-will not be recognised by {parser.prog} nor show up in --list output.
+will not be recognised by ssm-session nor show up in --list output.
 
 Visit https://aws.nz/aws-utils/ssm-session for more info and usage examples.
 
@@ -77,10 +77,10 @@ def update_env(env, var_names, var_value):
 def start_session(instance_id, profile=None, region=None):
     extra_args = ""
     if profile:
-        extra_args += f"--profile {profile} "
+        extra_args += "--profile {profile} ".format(profile=profile)
     if region:
-        extra_args += f"--region {region} "
-    command = f'aws {extra_args} ssm start-session --target {instance_id}'
+        extra_args += "--region {region} ".format(region=region)
+    command = 'aws {extra_args} ssm start-session --target {instance_id}'.format(extra_args=extra_args, instance_id=instance_id)
     logger.info("Running: %s", command)
     os.system(command)
 
@@ -170,7 +170,14 @@ class InstanceResolver():
             instname_len = max(instname_len, len(item['InstanceName']))
 
         for item in items:
-            print(f"{item['InstanceId']}   {item['HostName']:{hostname_len}}   {item['InstanceName']:{instname_len}}   {' '.join(item['Addresses'])}")
+            print(
+                "{id}   {hostname:{hostname_len}}   {instname:{instname_len}}   {addresses}".format(
+                    hostname_len=hostname_len,
+                    instname_len=instname_len,
+                    id=item['InstanceId'],
+                    hostname=item['HostName'],
+                    instname=item['InstanceName'],
+                    addresses=' '.join(item['Addresses'])))
 
     def resolve_instance(self, instance):
         # Is it a valid Instance ID?


### PR DESCRIPTION
This PR simplifies "ssm-session" a little so that it can run on both Python 2 or Python 3
At present, if you run it on a machine with only Python 2, you get:

```
$ ssm-session --list
  File "/usr/local/bin/ssm-session", line 65
    '''
      ^
SyntaxError: invalid syntax
```